### PR TITLE
Rename CI jobs and add integration test

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  golangci-lint:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -18,7 +18,7 @@ jobs:
         with:
           version: v2.10.1
 
-  tidy:
+  go-mod-tidy:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -28,7 +28,7 @@ jobs:
       - run: go mod tidy
       - run: git diff --exit-code go.mod go.sum
 
-  gofix:
+  go-fix:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -38,7 +38,7 @@ jobs:
       - run: go fix ./...
       - run: git diff --exit-code
 
-  test:
+  go-test:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -46,6 +46,15 @@ jobs:
         with:
           go-version: "1.26"
       - run: go test -race ./...
+
+  go-integration-test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6
+        with:
+          go-version: "1.26"
+      - run: go test -tags=integration -v ./test/integration/...
 
   docker:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary
- Rename CI job IDs to be more descriptive: `lint` → `golangci-lint`, `tidy` → `go-mod-tidy`, `gofix` → `go-fix`, `test` → `go-test`
- Add `go-integration-test` job that runs the zero-downtime redeployment integration test