### PR TITLE
Add location-aware routing

### DIFF
--- a/internal/council/provisioner.go
+++ b/internal/council/provisioner.go
@@ -82,7 +82,8 @@ func collectUsedPorts(king *state.King, currentState *state.State) map[int]bool 
 	return used
 }
 
-// ProvisionService assigns the first available king port to a service.
+// ProvisionService assigns the first available king port to a service,
+// preferring kings that match the service's PreferredLocation.
 func ProvisionService(currentState *state.State, service *state.Service) {
 	available := AvailableKingPorts(currentState)
 	if len(available) == 0 {
@@ -91,19 +92,30 @@ func ProvisionService(currentState *state.State, service *state.Service) {
 		return
 	}
 
-	first := available[0]
-	remotePort := first.Ports[0]
+	selected := available[0]
 
-	service.Host = &first.King.Host
+	if service.PreferredLocation != "" {
+		for _, candidate := range available {
+			if candidate.King.Location == service.PreferredLocation {
+				selected = candidate
+
+				break
+			}
+		}
+	}
+
+	remotePort := selected.Ports[0]
+
+	service.Host = &selected.King.Host
 	service.RemotePort = &remotePort
-	service.BindPort = &first.King.BindPort
+	service.BindPort = &selected.King.BindPort
 
 	currentState.Revision++
 
 	slog.Info("Provisioned service",
 		"name", service.Name,
-		"host", first.King.Host,
-		"bind_port", first.King.BindPort,
+		"host", selected.King.Host,
+		"bind_port", selected.King.BindPort,
 		"remote_port", remotePort,
 	)
 }

--- a/internal/council/provisioner_test.go
+++ b/internal/council/provisioner_test.go
@@ -568,3 +568,101 @@ func TestProvision_NoReprovisioning_WhenNoAvailableKing(t *testing.T) {
 		t.Fatalf("expected KingReady to be false")
 	}
 }
+
+func newTestKingWithLocation(
+	host, ports string, bindPort int, shuttingDown bool, location string,
+) state.King {
+	return state.King{
+		BindPort:     bindPort,
+		Host:         host,
+		Ports:        ports,
+		ShuttingDown: shuttingDown,
+		Beat:         0,
+		Location:     location,
+		CertPEM:      "",
+	}
+}
+
+func TestProvisionService_PrefersMatchingLocation(t *testing.T) {
+	t.Parallel()
+
+	currentState := &state.State{
+		Revision: 0,
+		Kings: []state.King{
+			newTestKingWithLocation(testHostA, "5000-5001", 2333, false, "us-east"),
+			newTestKingWithLocation(testHostB, "6000-6001", 2334, false, "eu-west"),
+		},
+		Services: []state.Service{
+			{
+				ServiceID:         "svc-1",
+				Name:              "alpha",
+				Token:             "",
+				LingID:            "",
+				PreferredLocation: "eu-west",
+				LingReady:         false,
+				KingReady:         false,
+				Host:              nil,
+				BindPort:          nil,
+				RemotePort:        nil,
+			},
+		},
+		Lings: nil,
+	}
+
+	council.ProvisionService(currentState, &currentState.Services[0])
+
+	svc := currentState.Services[0]
+	assertServiceHost(t, svc, testHostB)
+	assertServiceBindPort(t, svc, 2334)
+	assertServiceRemotePort(t, svc, 6000)
+}
+
+func TestProvisionService_FallsBackWhenPreferredLocationFull(t *testing.T) {
+	t.Parallel()
+
+	hostB := testHostB
+	bindPortB := 2334
+	port6000 := 6000
+
+	currentState := &state.State{
+		Revision: 0,
+		Kings: []state.King{
+			newTestKingWithLocation(testHostA, "5000-5001", 2333, false, "us-east"),
+			newTestKingWithLocation(testHostB, "6000-6000", 2334, false, "eu-west"),
+		},
+		Services: []state.Service{
+			{
+				ServiceID:         "existing",
+				Name:              "existing",
+				Token:             "",
+				LingID:            "",
+				PreferredLocation: "",
+				LingReady:         false,
+				KingReady:         false,
+				Host:              &hostB,
+				BindPort:          &bindPortB,
+				RemotePort:        &port6000,
+			},
+			{
+				ServiceID:         "svc-1",
+				Name:              "alpha",
+				Token:             "",
+				LingID:            "",
+				PreferredLocation: "eu-west",
+				LingReady:         false,
+				KingReady:         false,
+				Host:              nil,
+				BindPort:          nil,
+				RemotePort:        nil,
+			},
+		},
+		Lings: nil,
+	}
+
+	council.ProvisionService(currentState, &currentState.Services[1])
+
+	svc := currentState.Services[1]
+	assertServiceHost(t, svc, testHostA)
+	assertServiceBindPort(t, svc, 2333)
+	assertServiceRemotePort(t, svc, 5000)
+}

--- a/internal/council/provisioner_test.go
+++ b/internal/council/provisioner_test.go
@@ -570,13 +570,13 @@ func TestProvision_NoReprovisioning_WhenNoAvailableKing(t *testing.T) {
 }
 
 func newTestKingWithLocation(
-	host, ports string, bindPort int, shuttingDown bool, location string,
+	host, ports string, bindPort int, location string,
 ) state.King {
 	return state.King{
 		BindPort:     bindPort,
 		Host:         host,
 		Ports:        ports,
-		ShuttingDown: shuttingDown,
+		ShuttingDown: false,
 		Beat:         0,
 		Location:     location,
 		CertPEM:      "",
@@ -589,8 +589,8 @@ func TestProvisionService_PrefersMatchingLocation(t *testing.T) {
 	currentState := &state.State{
 		Revision: 0,
 		Kings: []state.King{
-			newTestKingWithLocation(testHostA, "5000-5001", 2333, false, "us-east"),
-			newTestKingWithLocation(testHostB, "6000-6001", 2334, false, "eu-west"),
+			newTestKingWithLocation(testHostA, "5000-5001", 2333, "us-east"),
+			newTestKingWithLocation(testHostB, "6000-6001", 2334, "eu-west"),
 		},
 		Services: []state.Service{
 			{
@@ -627,8 +627,8 @@ func TestProvisionService_FallsBackWhenPreferredLocationFull(t *testing.T) {
 	currentState := &state.State{
 		Revision: 0,
 		Kings: []state.King{
-			newTestKingWithLocation(testHostA, "5000-5001", 2333, false, "us-east"),
-			newTestKingWithLocation(testHostB, "6000-6000", 2334, false, "eu-west"),
+			newTestKingWithLocation(testHostA, "5000-5001", 2333, "us-east"),
+			newTestKingWithLocation(testHostB, "6000-6000", 2334, "eu-west"),
 		},
 		Services: []state.Service{
 			{

--- a/internal/ling/ling.go
+++ b/internal/ling/ling.go
@@ -253,7 +253,7 @@ func run(
 			stateMutex.Unlock()
 
 			OnStateChanged(
-				ctx, stateSnapshot, lingID,
+				ctx, stateSnapshot, lingID, preferredLocation,
 				tunnelMap, tunnelCli, tcpProxies,
 			)
 		},
@@ -435,13 +435,14 @@ func OnStateChanged(
 	ctx context.Context,
 	stateSnapshot *state.State,
 	lingID string,
+	preferredLocation string,
 	tunnelMap map[string]string,
 	tunnelCli *TunnelClient,
 	tcpProxies map[string]*TCPProxy,
 ) {
 	kings := buildKingIndex(stateSnapshot)
 	updateTunnelConnections(ctx, stateSnapshot, lingID, tunnelMap, tunnelCli, kings)
-	updateProxyTargets(stateSnapshot, tcpProxies, kings)
+	updateProxyTargets(stateSnapshot, preferredLocation, tcpProxies, kings)
 }
 
 // KingGroup holds the connection details for a group of services on a single king.
@@ -454,8 +455,9 @@ type KingGroup struct {
 
 // KingIndex stores health and certificate info for a king address.
 type KingIndex struct {
-	healthy bool
-	certPEM string
+	healthy  bool
+	certPEM  string
+	location string
 }
 
 func buildKingIndex(stateSnapshot *state.State) map[string]KingIndex {
@@ -463,7 +465,7 @@ func buildKingIndex(stateSnapshot *state.State) map[string]KingIndex {
 
 	for _, king := range stateSnapshot.Kings {
 		addr := net.JoinHostPort(king.Host, strconv.Itoa(king.BindPort))
-		index[addr] = KingIndex{healthy: !king.ShuttingDown, certPEM: king.CertPEM}
+		index[addr] = KingIndex{healthy: !king.ShuttingDown, certPEM: king.CertPEM, location: king.Location}
 	}
 
 	return index
@@ -551,12 +553,13 @@ func updateTunnelConnections(
 
 func updateProxyTargets(
 	stateSnapshot *state.State,
+	preferredLocation string,
 	tcpProxies map[string]*TCPProxy,
 	kings map[string]KingIndex,
 ) {
 	for proxyName, proxy := range tcpProxies {
 		targets := collectProxyTargets(
-			stateSnapshot, proxyName, kings,
+			stateSnapshot, proxyName, preferredLocation, kings,
 		)
 		proxy.updateTargets(targets)
 	}
@@ -589,20 +592,35 @@ func isServiceEligibleForProxy(
 func collectProxyTargets(
 	stateSnapshot *state.State,
 	proxyName string,
+	preferredLocation string,
 	kings map[string]KingIndex,
 ) []ProxyTarget {
-	targets := make([]ProxyTarget, 0, len(stateSnapshot.Services))
+	var allTargets []ProxyTarget
+	var preferredTargets []ProxyTarget
 
 	for _, svc := range stateSnapshot.Services {
 		if !isServiceEligibleForProxy(svc, proxyName, kings) {
 			continue
 		}
 
-		targets = append(targets, ProxyTarget{
+		target := ProxyTarget{
 			host:       *svc.Host,
 			remotePort: *svc.RemotePort,
-		})
+		}
+
+		allTargets = append(allTargets, target)
+
+		if preferredLocation != "" {
+			kingAddr := net.JoinHostPort(*svc.Host, strconv.Itoa(*svc.BindPort))
+			if king, exists := kings[kingAddr]; exists && king.location == preferredLocation {
+				preferredTargets = append(preferredTargets, target)
+			}
+		}
 	}
 
-	return targets
+	if len(preferredTargets) > 0 {
+		return preferredTargets
+	}
+
+	return allTargets
 }

--- a/internal/ling/ling.go
+++ b/internal/ling/ling.go
@@ -465,7 +465,11 @@ func buildKingIndex(stateSnapshot *state.State) map[string]KingIndex {
 
 	for _, king := range stateSnapshot.Kings {
 		addr := net.JoinHostPort(king.Host, strconv.Itoa(king.BindPort))
-		index[addr] = KingIndex{healthy: !king.ShuttingDown, certPEM: king.CertPEM, location: king.Location}
+		index[addr] = KingIndex{
+			healthy:  !king.ShuttingDown,
+			certPEM:  king.CertPEM,
+			location: king.Location,
+		}
 	}
 
 	return index
@@ -596,6 +600,7 @@ func collectProxyTargets(
 	kings map[string]KingIndex,
 ) []ProxyTarget {
 	var allTargets []ProxyTarget
+
 	var preferredTargets []ProxyTarget
 
 	for _, svc := range stateSnapshot.Services {

--- a/internal/ling/ling_test.go
+++ b/internal/ling/ling_test.go
@@ -445,7 +445,7 @@ func TestOnStateChanged_UpdatesProxyTargets(t *testing.T) {
 
 	ling.OnStateChanged(
 		context.Background(), stateSnapshot,
-		"other-ling", map[string]string{}, tunnelCli, tcpProxies,
+		"other-ling", "", map[string]string{}, tunnelCli, tcpProxies,
 	)
 
 	targets := proxy.ReadTargets()
@@ -474,7 +474,7 @@ func TestOnStateChanged_IncludesShuttingDownLing(t *testing.T) {
 
 	ling.OnStateChanged(
 		context.Background(), stateSnapshot,
-		"other-ling", map[string]string{}, tunnelCli, tcpProxies,
+		"other-ling", "", map[string]string{}, tunnelCli, tcpProxies,
 	)
 
 	targets := proxy.ReadTargets()
@@ -503,7 +503,7 @@ func TestOnStateChanged_ExcludesShuttingDownKing(t *testing.T) {
 
 	ling.OnStateChanged(
 		context.Background(), stateSnapshot,
-		"other-ling", map[string]string{}, tunnelCli, tcpProxies,
+		"other-ling", "", map[string]string{}, tunnelCli, tcpProxies,
 	)
 
 	targets := proxy.ReadTargets()
@@ -532,7 +532,7 @@ func TestOnStateChanged_ExcludesNotReady(t *testing.T) {
 
 	ling.OnStateChanged(
 		context.Background(), stateSnapshot,
-		"other-ling", map[string]string{}, tunnelCli, tcpProxies,
+		"other-ling", "", map[string]string{}, tunnelCli, tcpProxies,
 	)
 
 	targets := proxy.ReadTargets()
@@ -561,12 +561,114 @@ func TestOnStateChanged_ExcludesMissingHostOrPort(t *testing.T) {
 
 	ling.OnStateChanged(
 		context.Background(), stateSnapshot,
-		"other-ling", map[string]string{}, tunnelCli, tcpProxies,
+		"other-ling", "", map[string]string{}, tunnelCli, tcpProxies,
 	)
 
 	targets := proxy.ReadTargets()
 
 	if len(targets) != 0 {
 		t.Errorf("expected 0 targets (nil host/port), got %d", len(targets))
+	}
+}
+
+func buildLocationState() *state.State {
+	hostA := "10.0.0.1"
+	hostB := "10.0.0.2"
+	bindPortA := 5000
+	bindPortB := 5001
+	remotePortA := 12345
+	remotePortB := 12346
+
+	return &state.State{
+		Revision: 0,
+		Kings: []state.King{
+			{
+				BindPort:     bindPortA,
+				Host:         hostA,
+				Ports:        "",
+				ShuttingDown: false,
+				Beat:         0,
+				Location:     "eu-west",
+				CertPEM:      "",
+			},
+			{
+				BindPort:     bindPortB,
+				Host:         hostB,
+				Ports:        "",
+				ShuttingDown: false,
+				Beat:         0,
+				Location:     "us-east",
+				CertPEM:      "",
+			},
+		},
+		Services: []state.Service{
+			{
+				ServiceID:         "svc-1",
+				Name:              "myproxy",
+				Token:             "",
+				LingID:            "ling-a",
+				PreferredLocation: "",
+				LingReady:         true,
+				KingReady:         true,
+				Host:              &hostA,
+				BindPort:          &bindPortA,
+				RemotePort:        &remotePortA,
+			},
+			{
+				ServiceID:         "svc-2",
+				Name:              "myproxy",
+				Token:             "",
+				LingID:            "ling-b",
+				PreferredLocation: "",
+				LingReady:         true,
+				KingReady:         true,
+				Host:              &hostB,
+				BindPort:          &bindPortB,
+				RemotePort:        &remotePortB,
+			},
+		},
+		Lings: nil,
+	}
+}
+
+func TestOnStateChanged_PrefersLocationTargets(t *testing.T) {
+	t.Parallel()
+
+	stateSnapshot := buildLocationState()
+
+	proxy := ling.NewTCPProxy("myproxy", 0)
+	tcpProxies := map[string]*ling.TCPProxy{"myproxy": proxy}
+	tunnelCli := ling.NewTunnelClient()
+
+	ling.OnStateChanged(
+		context.Background(), stateSnapshot,
+		"other-ling", "eu-west", map[string]string{}, tunnelCli, tcpProxies,
+	)
+
+	targets := proxy.ReadTargets()
+
+	if len(targets) != 1 {
+		t.Fatalf("expected 1 target (preferred location), got %d", len(targets))
+	}
+}
+
+func TestOnStateChanged_FallsBackWhenNoPreferredLocationTargets(t *testing.T) {
+	t.Parallel()
+
+	stateSnapshot := buildLocationState()
+
+	proxy := ling.NewTCPProxy("myproxy", 0)
+	tcpProxies := map[string]*ling.TCPProxy{"myproxy": proxy}
+	tunnelCli := ling.NewTunnelClient()
+
+	ling.OnStateChanged(
+		context.Background(), stateSnapshot,
+		"other-ling", "ap-south", map[string]string{}, tunnelCli, tcpProxies,
+	)
+
+	targets := proxy.ReadTargets()
+
+	if len(targets) != 2 {
+		t.Fatalf("expected 2 targets (fallback to all), got %d", len(targets))
 	}
 }


### PR DESCRIPTION
## Summary
- Ling proxy prefers targets on kings matching its preferred location, falls back to all targets when none match
- Council provisioner prefers kings matching a service's preferred location when assigning ports
- Added `location` field to `KingIndex` for location-aware target filtering

## Test plan
- [x] Existing tests updated with new `preferredLocation` parameter
- [x] New tests for preferred location target selection and fallback
- [x] New tests for location-aware provisioning and fallback

Closes #14